### PR TITLE
[feat] 뉴스 상세조회 화면 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,16 @@
 <!--                <category android:name="android.intent.category.LAUNCHER" />-->
 <!--            </intent-filter>-->
         </activity>
+
+
+        <activity android:name=".presentation.ui.news.NewsDetailActivity"
+            android:exported="true">
+<!--                <intent-filter>-->
+<!--                    <action android:name="android.intent.action.MAIN" />-->
+
+<!--                    <category android:name="android.intent.category.LAUNCHER" />-->
+<!--                </intent-filter>-->
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/model/NewsDetailItem.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/model/NewsDetailItem.kt
@@ -1,0 +1,12 @@
+package com.example.news_eat_fronted.presentation.model
+
+data class NewsDetailItem(
+    val id: Int,
+    val imgResId: String,
+    val title: String,
+    val publisher: String,
+    val date: String,
+    val category: String,
+    val sentiment: String,
+    val content: String
+)

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
@@ -1,0 +1,126 @@
+package com.example.news_eat_fronted.presentation.ui.news
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bumptech.glide.Glide
+import com.example.news_eat_fronted.R
+import com.example.news_eat_fronted.databinding.ActivityNewsDetailBinding
+import com.example.news_eat_fronted.util.base.BindingActivity
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+class NewsDetailActivity : BindingActivity<ActivityNewsDetailBinding>(R.layout.activity_news_detail) {
+
+    private val viewModel: NewsViewModel by viewModels()
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
+    private lateinit var adapter: RVAdapterRecommendNews
+
+    private val offsetFromTopDp = 250
+    private var isTTSActive = false
+    private var isBookmarked = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setupRecyclerView()
+        setupBottomSheet()
+        observeViewModel()
+        setupBackButton()
+        setupFloatingButton()
+        setupBookmarkButton()
+    }
+
+    private fun setupRecyclerView() {
+        adapter = RVAdapterRecommendNews { item ->
+            viewModel.selectNews(item)
+        }
+        binding.rvNewsRecommended.layoutManager =
+            LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
+        binding.rvNewsRecommended.adapter = adapter
+    }
+
+    private fun setupBottomSheet() {
+        bottomSheetBehavior = BottomSheetBehavior.from(binding.bottomSheet)
+
+        val density = resources.displayMetrics.density
+        val offsetFromTopPx = (offsetFromTopDp * density).toInt()
+
+        // 레이아웃이 그려진 후 높이 계산
+        binding.bottomSheet.post {
+            val screenHeight = resources.displayMetrics.heightPixels
+            val peekHeight = screenHeight - offsetFromTopPx
+            bottomSheetBehavior.peekHeight = peekHeight.coerceAtLeast(0)
+
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+
+        bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) { }
+            override fun onSlide(bottomSheet: View, slideOffset: Float) { }
+        })
+    }
+
+    private fun observeViewModel() {
+
+        viewModel.selectedNewsTitle.observe(this) {
+            binding.newsTitle.text = it
+        }
+
+        viewModel.selectedNewsImgResId.observe(this) { imageUrl ->
+            Glide.with(this)
+                .load(imageUrl)
+                .into(binding.newsImage)
+        }
+
+        viewModel.selectedNewsPublisher.observe(this) {
+            binding.newsPublisher.text = it
+        }
+        viewModel.selectedNewsDate.observe(this) {
+            binding.newsDate.text = it
+        }
+        viewModel.selectedNewsCategory.observe(this) {
+            binding.newsCategory.text = it
+        }
+        viewModel.selectedNewsSentiment.observe(this) {
+            binding.newsSentiment.text = it
+        }
+        viewModel.selectedNewsContent.observe(this) {
+            binding.newsContent.text = it
+        }
+
+        viewModel.recommendNewsList.observe(this) {
+            adapter.submitList(it)
+        }
+    }
+
+    private fun setupBackButton() {
+        binding.roundBackButton.setOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
+    private fun setupFloatingButton() {
+        binding.fabWrite.setOnClickListener {
+            isTTSActive = !isTTSActive
+
+            if (isTTSActive) {
+                binding.fabWrite.setImageResource(R.drawable.icon_tts_stop)
+            } else {
+                binding.fabWrite.setImageResource(R.drawable.icon_tts)
+            }
+        }
+    }
+
+    private fun setupBookmarkButton() {
+        binding.roundBookmarkButton.setOnClickListener {
+            isBookmarked = !isBookmarked
+
+            if (isBookmarked) {
+                binding.roundBookmarkButton.setImageResource(R.drawable.btn_round_bookmark_selected)
+            } else {
+                binding.roundBookmarkButton.setImageResource(R.drawable.btn_round_bookmark_unselected)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsViewModel.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsViewModel.kt
@@ -1,0 +1,65 @@
+package com.example.news_eat_fronted.presentation.ui.news
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.news_eat_fronted.presentation.model.NewsDetailItem
+
+class NewsViewModel : ViewModel() {
+
+    private val _selectedNewsTitle = MutableLiveData<String>()
+    val selectedNewsTitle: LiveData<String> = _selectedNewsTitle
+
+    private val _selectedNewsImgResId = MutableLiveData<String>()
+    val selectedNewsImgResId: LiveData<String> = _selectedNewsImgResId
+
+    private val _selectedNewsPublisher = MutableLiveData<String>()
+    val selectedNewsPublisher: LiveData<String> = _selectedNewsPublisher
+
+    private val _selectedNewsDate = MutableLiveData<String>()
+    val selectedNewsDate: LiveData<String> = _selectedNewsDate
+
+    private val _selectedNewsCategory = MutableLiveData<String>()
+    val selectedNewsCategory: LiveData<String> = _selectedNewsCategory
+
+    private val _selectedNewsSentiment = MutableLiveData<String>()
+    val selectedNewsSentiment: LiveData<String> = _selectedNewsSentiment
+
+    private val _selectedNewsContent = MutableLiveData<String>()
+    val selectedNewsContent: LiveData<String> = _selectedNewsContent
+
+    private val _recommendNewsList = MutableLiveData<List<NewsDetailItem>>()
+    val recommendNewsList: LiveData<List<NewsDetailItem>> = _recommendNewsList
+
+    init {
+        loadDummyNews()
+    }
+
+    private fun loadDummyNews() {
+        _selectedNewsTitle.value = "“책임과 업무만 늘어나”…리더 꺼리는 2030 직장인"
+        _selectedNewsImgResId.value = "https://cphoto.asiae.co.kr/listimglink/1/2025051719272061633_1747477641.jpg"
+        _selectedNewsPublisher.value = "문화일보"
+        _selectedNewsDate.value = "2025.05.25"
+        _selectedNewsCategory.value = "세계"
+        _selectedNewsSentiment.value = "긍정"
+        _selectedNewsContent.value = "성공의 척도로 여겨지던 ‘초고속 승진’도 이제 옛말이 되는 것일까. 20~30세대 젊은 직장인 사이에서는 ‘리더를 하지 않겠다’는 분위기가 확산하고 있다. 이른바 ‘리더 포비아’ 혹은 ‘언보싱’이라고 불리는 이 현상은 성과 압박과 업무량 부담을 피하고 싶은 마음에서 비롯된 것으로 분석된다. \u2028\u2028대학내일20대연구소가 발표한 ‘20·30 직장인의 리더 인식 기획조사 2025’에 따르면 공기업과 사기업에 재직 중인 19~36세 850명을 대상으로 조사한 결과, 47.3%는 “향후 리더 역할을 맡지 않아도 불안하지 않다”고 대답했다. 반면 “불안하다”고 답한 비율은 22.1%에 불과했다. \u2028\u2028‘중간관리직을 맡을 의향’에 대해서는 “있다”는 사람과 “없다” 사람이 각각 36.7%와 32.5%로 비슷했다. \u2028\u2028리더 포비아는 리더(Leader)와 공포증을 뜻하는 포비아(Phobia)의 합성어다. 단순히 리더가 되기 싫은 것을 넘어 리더 역할에 대한 심리적인 거부감과 두려움이 높은 상태를 의미한다. 언보싱(Unbossing)은 리더의 역할이나 관리직을 의도적으로 회피하고 개인의 성장과 삶의 균형을 중시하는 경향을 뜻한다. \u2028\u2028그렇다면 리더 직을 기피하는 이유(중복 응답)는 무엇일까. \u2028\u2028참여자들은 성과에 대한 부담(42.8%)을 가장 많이 꼽았다. 리더로 승진 시 늘어나는 업무량(41.6%)도 비슷한 비중을 차지했다. 단순하게 ‘관리 직무가 개인 성향에 맞지 않는다’는 응답도 33.7%를 차지했다. \u2028\u2028다만 기업 형태에 따라 기피 이유는 조금씩 달랐다. 대기업 재직자는 업무량 증가(47.1%)를 가장 많이 꼽았지만, 중소기업 재직자는 ‘팀 성과 책임(42.8%)’을 1위로 들었다. 공기업 재직자는 팀원 성장 책임(48.6%)을 리더 직을 꺼리는 가장 큰 이유로 꼽았다. \u2028\u2028리더 직을 맡겠다는 응답자들은 그 이유로 ▲급여·복지 혜택(41.4%) ▲조직 내 인정(33.3%) ▲경력 개발 기회 30.8% 등을 선택했다. \u2028\u2028리더 역할에 대한 인식은 기업마다 달랐다. 대기업은 목표 설정(36.3%)과 내·외부 조율(34.1%)을, 공기업은 조직문화 조성(40.4%)과 성과 관리(25.8%)를 주요 업무로 봤다. 모든 기업에서 공통으로 꼽은 리더의 역할은 소통과 팀워크 강화였다. 업무 조정과 분배도 중요한 리더 업무로 인식됐다. \u2028\u2028대학내일20대연구소 관계자는 “20~30세대 직장인들이 리더 역할의 필요성을 적게 느끼고 있다”며 “젊은 세대가 승진보다 개인의 삶과 균형을 중시하는 가치관 변화를 반영한 결과로 풀이된다”고 말했다."
+
+        _recommendNewsList.value = listOf(
+            NewsDetailItem(id = 1, "https://cphoto.asiae.co.kr/listimglink/1/2025051719272061633_1747477641.jpg", "‘던파’ 흥행에 넥슨 네오플 평균 연봉 2.2억원…업계 1위-뉴스제목입니다 최대 두줄노출", "아시아경제", "2025.05.20", "경제", "긍정", "내용입니다."),
+            NewsDetailItem(id = 2, "https://imgnews.pstatic.net/image/003/2025/08/07/NISI20250807_0001912788_web_20250807103749_20250807104215055.jpg?type=w647", "실리콘밸리에 VC 만드는 네이버…\"AI 총력전\"", "아시아경제", "2025.05.20", "경제", "긍정", "내용입니다."),
+            NewsDetailItem(id = 3, "https://file2.nocutnews.co.kr/newsroom/image/2024/04/01/202404011752096007_0.jpg", "이제 겨우 스물네살인데, 영구결번 전설적 투수를 넘어섰다…역사를 쓰는 정해영", "아시아경제", "2025.05.20", "경제", "긍정", "내용입니다."),
+            NewsDetailItem(id = 4, "https://imgnews.pstatic.net/image/003/2025/08/07/NISI20250807_0001912788_web_20250807103749_20250807104215055.jpg?type=w647", "실리콘밸리에 VC 만드는 네이버…\"AI 총력전\"", "아시아경제", "2025.05.20", "경제", "긍정", "내용입니다."),
+            NewsDetailItem(id = 5, "https://file2.nocutnews.co.kr/newsroom/image/2024/04/01/202404011752096007_0.jpg", "이제 겨우 스물네살인데, 영구결번 전설적 투수를 넘어섰다…역사를 쓰는 정해영", "아시아경제", "2025.05.20", "경제", "긍정", "내용입니다."),
+        )
+    }
+
+    fun selectNews(item: NewsDetailItem) {
+        _selectedNewsTitle.value = item.title
+        _selectedNewsImgResId.value = item.imgResId
+        _selectedNewsPublisher.value = item.publisher
+        _selectedNewsDate.value = item.date
+        _selectedNewsCategory.value = item.category
+        _selectedNewsSentiment.value = item.sentiment
+        _selectedNewsContent.value = item.content
+    }
+}

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/RVAdapterRecommendNews.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/RVAdapterRecommendNews.kt
@@ -1,0 +1,52 @@
+package com.example.news_eat_fronted.presentation.ui.news
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+
+import com.example.news_eat_fronted.databinding.RvRecommendNewsItemBinding
+import com.example.news_eat_fronted.presentation.model.NewsDetailItem
+
+class RVAdapterRecommendNews(
+    private val onClickItem: ((NewsDetailItem) -> Unit)? = null
+) : ListAdapter<NewsDetailItem, RVAdapterRecommendNews.ViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RVAdapterRecommendNews.ViewHolder {
+        val binding = RvRecommendNewsItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: RVAdapterRecommendNews.ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ViewHolder(private val binding: RvRecommendNewsItemBinding): RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: NewsDetailItem) {
+            Glide.with(binding.root)
+//                .load(binding.root.context.resources.getIdentifier(item.imgResId, "drawable", binding.root.context.packageName))
+                .load(item.imgResId)
+                .into(binding.ivHomeNews)
+            binding.tvHomeNews.text = item.title
+
+            binding.root.setOnClickListener {
+                onClickItem?.invoke(item)
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object: DiffUtil.ItemCallback<NewsDetailItem>() {
+            override fun areItemsTheSame(oldItem: NewsDetailItem, newItem: NewsDetailItem): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: NewsDetailItem, newItem: NewsDetailItem): Boolean {
+                return oldItem == newItem
+            }
+
+        }
+    }
+}

--- a/app/src/main/res/drawable/background_rounded_bottomsheet.xml
+++ b/app/src/main/res/drawable/background_rounded_bottomsheet.xml
@@ -1,4 +1,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <solid android:color="@color/Gray100" />
-    <corners android:topLeftRadius="30dp" android:topRightRadius="16dp" />
+    <corners android:topLeftRadius="20dp" android:topRightRadius="20dp" />
 </shape>

--- a/app/src/main/res/drawable/background_rounded_bottomsheet.xml
+++ b/app/src/main/res/drawable/background_rounded_bottomsheet.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/Gray100" />
+    <corners android:topLeftRadius="30dp" android:topRightRadius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/background_summary_button.xml
+++ b/app/src/main/res/drawable/background_summary_button.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/Primary600" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/btn_round_back.xml
+++ b/app/src/main/res/drawable/btn_round_back.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="34dp"
+    android:height="34dp"
+    android:viewportWidth="34"
+    android:viewportHeight="34">
+  <path
+      android:pathData="M17,17m-17,0a17,17 0,1 1,34 0a17,17 0,1 1,-34 0"
+      android:fillColor="#8490A0"
+      android:fillAlpha="0.6"/>
+  <path
+      android:pathData="M20,9L12,17L20,25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/btn_round_bookmark_selected.xml
+++ b/app/src/main/res/drawable/btn_round_bookmark_selected.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="34dp"
+    android:height="34dp"
+    android:viewportWidth="34"
+    android:viewportHeight="34">
+  <path
+      android:pathData="M17,17m-17,0a17,17 0,1 1,34 0a17,17 0,1 1,-34 0"
+      android:fillColor="#8490A0"
+      android:fillAlpha="0.6"/>
+  <group>
+    <clip-path
+        android:pathData="M5,5h24v24h-24z"/>
+    <path
+        android:pathData="M21,9.25C21.966,9.25 22.75,10.033 22.75,11V22.144C22.75,23.537 21.201,24.372 20.037,23.605L17.138,21.694C17.054,21.639 16.946,21.639 16.862,21.694L13.963,23.605C12.799,24.372 11.25,23.537 11.25,22.144V11C11.25,10.033 12.033,9.25 13,9.25H21Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.5"
+        android:fillColor="#ffffff"
+        android:strokeColor="#ffffff"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/btn_round_bookmark_unselected.xml
+++ b/app/src/main/res/drawable/btn_round_bookmark_unselected.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="34dp"
+    android:height="34dp"
+    android:viewportWidth="34"
+    android:viewportHeight="34">
+  <path
+      android:pathData="M17,17m-17,0a17,17 0,1 1,34 0a17,17 0,1 1,-34 0"
+      android:fillColor="#8490A0"
+      android:fillAlpha="0.6"/>
+  <group>
+    <clip-path
+        android:pathData="M5,5h24v24h-24z"/>
+    <path
+        android:pathData="M21,9.25C21.966,9.25 22.75,10.033 22.75,11V22.144C22.75,23.537 21.201,24.372 20.037,23.605L17.138,21.694C17.054,21.639 16.946,21.639 16.862,21.694L13.963,23.605C12.799,24.372 11.25,23.537 11.25,22.144V11C11.25,10.033 12.033,9.25 13,9.25H21Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.5"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/icon_tts.xml
+++ b/app/src/main/res/drawable/icon_tts.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="30"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M3.948,17.413C3.057,15.928 3.057,14.072 3.948,12.587V12.587C4.22,12.133 4.671,11.816 5.189,11.712L7.305,11.289C7.431,11.264 7.545,11.196 7.627,11.097L10.921,7.145C12.103,5.726 12.695,5.016 13.222,5.207C13.75,5.398 13.75,6.322 13.75,8.169L13.75,21.831C13.75,23.678 13.75,24.601 13.222,24.793C12.695,24.984 12.103,24.274 10.921,22.855L7.627,18.903C7.545,18.804 7.431,18.736 7.305,18.711L5.189,18.288C4.671,18.184 4.22,17.867 3.948,17.413V17.413Z"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="M19.419,10.581C20.586,11.747 21.243,13.326 21.25,14.975C21.256,16.624 20.611,18.209 19.454,19.385"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M24.571,7.929C26.437,9.795 27.49,12.322 27.5,14.961C27.51,17.599 26.478,20.135 24.627,22.015"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/icon_tts_stop.xml
+++ b/app/src/main/res/drawable/icon_tts_stop.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="30"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M8.5,6.25L11.5,6.25A1,1 0,0 1,12.5 7.25L12.5,22.75A1,1 0,0 1,11.5 23.75L8.5,23.75A1,1 0,0 1,7.5 22.75L7.5,7.25A1,1 0,0 1,8.5 6.25z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M18.5,6.25L21.5,6.25A1,1 0,0 1,22.5 7.25L22.5,22.75A1,1 0,0 1,21.5 23.75L18.5,23.75A1,1 0,0 1,17.5 22.75L17.5,7.25A1,1 0,0 1,18.5 6.25z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/layout/activity_news_detail.xml
+++ b/app/src/main/res/layout/activity_news_detail.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:id="@+id/image_container"
+            android:layout_width="match_parent"
+            android:layout_height="270dp">
+
+            <ImageView
+                android:id="@+id/news_image"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="centerCrop"
+                android:src="@drawable/dummy_gradient_background" />
+
+            <ImageButton
+                android:id="@+id/round_back_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/btn_round_back"
+                android:contentDescription="뒤로가기"
+                android:layout_gravity="start|top"/>
+
+            <ImageButton
+                android:id="@+id/round_bookmark_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/btn_round_bookmark_unselected"
+                android:contentDescription="북마크"
+                android:layout_gravity="end|top"/>
+        </FrameLayout>
+
+        <!-- 바텀 시트 -->
+        <LinearLayout
+            android:id="@+id/bottom_sheet"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="bottom"
+            android:background="@drawable/background_rounded_bottomsheet"
+            android:orientation="vertical"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/news_scroll_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fillViewport="true"
+                android:scrollbars="vertical" >
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:clipToPadding="false">
+
+                    <!-- 뉴스 제목-->
+                    <TextView
+                        android:id="@+id/news_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="16dp"
+                        android:paddingTop="23dp"
+                        android:paddingBottom="16dp"
+                        android:text="@string/news_detail_title"
+                        android:textAppearance="@style/TextAppearance.NewsEat.Title3"
+                        android:textColor="@color/Gray800"
+                        android:lineSpacingExtra="4dp" />
+
+                    <!-- 언론사, 날짜, 카테고리, 감정-->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="30dp"
+                        android:layout_marginHorizontal="16dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:layout_weight="1">
+
+                            <TextView
+                                android:id="@+id/news_publisher"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/news_detail_publisher"
+                                android:textAppearance="@style/TextAppearance.NewsEat.Body8"
+                                android:textColor="@color/Gray400" />
+
+                            <View
+                                android:layout_width="1dp"
+                                android:layout_height="12dp"
+                                android:layout_marginHorizontal="7dp"
+                                android:background="@color/Gray300" />
+
+                            <TextView
+                                android:id="@+id/news_date"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/news_detail_date"
+                                android:textAppearance="@style/TextAppearance.NewsEat.Body8"
+                                android:textColor="@color/Gray400" />
+
+                            <View
+                                android:layout_width="1dp"
+                                android:layout_height="12dp"
+                                android:layout_marginHorizontal="7dp"
+                                android:background="@color/Gray300" />
+
+                            <TextView
+                                android:id="@+id/news_category"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/news_detail_category"
+                                android:textAppearance="@style/TextAppearance.NewsEat.Body8"
+                                android:textColor="@color/Gray400" />
+
+                            <View
+                                android:layout_width="1dp"
+                                android:layout_height="12dp"
+                                android:layout_marginHorizontal="7dp"
+                                android:background="@color/Gray300" />
+
+                            <TextView
+                                android:id="@+id/news_sentiment"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/news_detail_sentiment"
+                                android:textAppearance="@style/TextAppearance.NewsEat.Body8"
+                                android:textColor="@color/Gray400" />
+                        </LinearLayout>
+
+                        <Button
+                            android:id="@+id/rounded_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingHorizontal="7dp"
+                            android:paddingVertical="4dp"
+                            android:text="@string/news_detail_summary_button"
+                            android:textColor="@color/Gray100"
+                            android:textAppearance="@style/TextAppearance.NewsEat.Body11"
+                            android:background="@drawable/background_summary_button" />
+
+                    </LinearLayout>
+
+                    <!-- 뉴스 본문 -->
+                    <TextView
+                        android:id="@+id/news_content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:layout_marginHorizontal="16dp"
+                        android:text="@string/news_detail_content"
+                        android:textAppearance="@style/TextAppearance.NewsEat.Body7"
+                        android:textColor="@color/Gray800"
+                        android:lineSpacingExtra="4dp"
+                        android:layout_marginBottom="16dp" />
+
+                    <View
+                        android:id="@+id/news_detail_diver"
+                        android:layout_width="match_parent"
+                        android:layout_height="8dp"
+                        android:layout_marginTop="34dp"
+                        android:background="@color/Gray200" />
+
+                    <TextView
+                        android:id="@+id/news_recommend_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="16dp"
+                        android:layout_marginTop="25dp"
+                        android:layout_marginBottom="16dp"
+                        android:text="@string/news_detail_recommend_title"
+                        android:textAppearance="@style/TextAppearance.NewsEat.Title4"
+                        android:textColor="@color/Gray800" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/rv_news_recommended"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginBottom="30dp"
+                        android:scrollbars="none"
+                        android:nestedScrollingEnabled="false" />
+
+                </LinearLayout>
+            </androidx.core.widget.NestedScrollView>
+        </LinearLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_write"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="20dp"
+            android:layout_gravity="bottom|end"
+            android:backgroundTint="@color/Primary600"
+            android:src="@drawable/icon_tts"
+            app:tint="@color/white" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/rv_recommend_news_item.xml
+++ b/app/src/main/res/layout/rv_recommend_news_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+        <ImageView
+            android:id="@+id/iv_home_news"
+            android:layout_width="210dp"
+            android:layout_height="117dp"
+            android:src="@drawable/dummy_gradient_background"
+            android:background="@drawable/background_rounded_image"
+            android:clipToOutline="true"
+            android:scaleType="centerCrop"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_home_news"
+            android:layout_width="210dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="‘던파’ 흥행에 넥슨 네오플 평균 연봉 2.2억원…업계 1위-뉴스제목입니다 최대 두줄노출"
+            android:textAppearance="@style/TextAppearance.NewsEat.Body10"
+            android:textColor="@color/Gray800"
+            android:maxLines="2"
+            android:ellipsize="end"
+            app:layout_constraintTop_toBottomOf="@id/iv_home_news"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <View
+            android:layout_width="16dp"
+            android:layout_height="1dp"
+            app:layout_constraintStart_toEndOf="@id/iv_home_news"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,17 @@
     <string name="bookmark_card_view_category">%s</string>
     <string name="bookmark_card_view_date">%s</string>
 
+    <!-- 뉴스 상세 뷰-->
+    <string name="news_detail_title">%s</string>
+    <string name="news_detail_publisher">%s</string>
+    <string name="news_detail_date">%s</string>
+    <string name="news_detail_category">%s</string>
+    <string name="news_detail_sentiment">%s</string>
+    <string name="news_detail_content">%s</string>
+    <string name="news_detail_summary_button">뉴스요약 확인하기</string>
+
+    <string name="news_detail_recommend_title">추천 뉴스 더보기</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #8


## ✏️ 작업 내용

- 뉴스 상세조회 화면 구현
  - 뉴스 본문 부분 바텀시트 형태로 구현
  - 뉴스상세조회 데이터 클래스, 추천뉴스 rv 어댑터, 뷰모델, 액티비티 구현

## 📸 스크린샷
<img width="372" height="806" alt="뉴스뷰" src="https://github.com/user-attachments/assets/1c6fdec3-6af8-48c8-a40c-fc74576e2aa2" />

## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
- Activity 파일에서 바텀시트 시작높이를 지정하는 로직 괜찮은지 봐주시면 좋을 거 같습니다 !!
