### PR TITLE
[feat] 북마크/홈화면 API 연결

### DIFF
--- a/app/src/main/java/com/example/news_eat_fronted/data/datasource/BookmarkRemoteDataSource.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasource/BookmarkRemoteDataSource.kt
@@ -7,6 +7,7 @@ import com.example.news_eat_fronted.data.model.response.bookmark.BookmarkIdRespo
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkListResponseDto
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkedNewsDetailResponseDto
 import com.example.news_eat_fronted.data.model.response.news.GetCategoryNewsResponseDto
+import com.example.news_eat_fronted.data.model.response.news.NewsSummaryResponseDto
 
 interface BookmarkRemoteDataSource {
     suspend fun postBookmark(newsId: Long): BaseResponse<BookmarkIdResponseDto>
@@ -16,4 +17,6 @@ interface BookmarkRemoteDataSource {
     suspend fun getBookmarkList(getBookmarkListRequestDto: GetBookmarkListRequestDto): BaseResponse<GetBookmarkListResponseDto>
 
     suspend fun getBookmarkedNewsDetail(bookmarkId: Long): BaseResponse<GetBookmarkedNewsDetailResponseDto>
+
+    suspend fun getBookmarkedNewsSummary(bookmarkId: Long): BaseResponse<NewsSummaryResponseDto>
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/datasource/HomeRemoteDataSource.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasource/HomeRemoteDataSource.kt
@@ -2,7 +2,10 @@ package com.example.news_eat_fronted.data.datasource
 
 import com.example.news_eat_fronted.data.model.BaseResponse
 import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+import com.example.news_eat_fronted.data.model.response.home.GetLatestNewsResponseDto
 
 interface HomeRemoteDataSource {
     suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
+
+    suspend fun getLatestNews(): BaseResponse<GetLatestNewsResponseDto>
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/datasource/HomeRemoteDataSource.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasource/HomeRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.news_eat_fronted.data.datasource
+
+import com.example.news_eat_fronted.data.model.BaseResponse
+import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+
+interface HomeRemoteDataSource {
+    suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/BookmarkRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/BookmarkRemoteDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.example.news_eat_fronted.data.model.request.bookmark.GetBookmarkListR
 import com.example.news_eat_fronted.data.model.response.bookmark.BookmarkIdResponseDto
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkListResponseDto
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkedNewsDetailResponseDto
+import com.example.news_eat_fronted.data.model.response.news.NewsSummaryResponseDto
 import com.example.news_eat_fronted.data.service.BookmarkService
 import javax.inject.Inject
 
@@ -26,4 +27,7 @@ class BookmarkRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun getBookmarkedNewsDetail(bookmarkId: Long): BaseResponse<GetBookmarkedNewsDetailResponseDto>
     = bookmarkService.getBookmarkedNewsDetail(bookmarkId)
+
+    override suspend fun getBookmarkedNewsSummary(bookmarkId: Long): BaseResponse<NewsSummaryResponseDto>
+    = bookmarkService.getBookmarkedNewsSummary(bookmarkId)
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/HomeRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/HomeRemoteDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.example.news_eat_fronted.data.datasourceImpl
 import com.example.news_eat_fronted.data.datasource.HomeRemoteDataSource
 import com.example.news_eat_fronted.data.model.BaseResponse
 import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+import com.example.news_eat_fronted.data.model.response.home.GetLatestNewsResponseDto
 import com.example.news_eat_fronted.data.service.HomeService
 import javax.inject.Inject
 
@@ -11,4 +12,7 @@ class HomeRemoteDataSourceImpl @Inject constructor(
 ): HomeRemoteDataSource {
     override suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
     = homeService.getHomeNewsSections()
+
+    override suspend fun getLatestNews(): BaseResponse<GetLatestNewsResponseDto>
+    = homeService.getLatestNews()
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/HomeRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/datasourceImpl/HomeRemoteDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.example.news_eat_fronted.data.datasourceImpl
+
+import com.example.news_eat_fronted.data.datasource.HomeRemoteDataSource
+import com.example.news_eat_fronted.data.model.BaseResponse
+import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+import com.example.news_eat_fronted.data.service.HomeService
+import javax.inject.Inject
+
+class HomeRemoteDataSourceImpl @Inject constructor(
+    private val homeService: HomeService
+): HomeRemoteDataSource {
+    override suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
+    = homeService.getHomeNewsSections()
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/bookmark/GetBookmarkListResponseDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/bookmark/GetBookmarkListResponseDto.kt
@@ -20,14 +20,17 @@ data class GetBookmarkListResponseDto(
         @SerializedName("imgUrl")
         val imgUrl: String,
         @SerializedName("publishedAt")
-        val publishedAt: String
+        val publishedAt: String,
+        @SerializedName("newsDeleted")
+        val newsDeleted: Boolean
     ) {
         fun toBookmarkResponseEntity() = BookmarkResponseEntity(
             bookmarkId = bookmarkId,
             title = title,
             category = category,
             imgUrl = imgUrl,
-            publishedAt = publishedAt
+            publishedAt = publishedAt,
+            newsDeleted = newsDeleted
         )
     }
 

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/bookmark/GetBookmarkedNewsDetailResponseDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/bookmark/GetBookmarkedNewsDetailResponseDto.kt
@@ -19,7 +19,9 @@ data class GetBookmarkedNewsDetailResponseDto (
     @SerializedName("imgUrl")
     val imgUrl: String,
     @SerializedName("category")
-    val category: String
+    val category: String,
+    @SerializedName("newsDeleted")
+    val newsDeleted: Boolean
 ) {
     fun toGetBookmarkedNewsDetailResponseEntity() = GetBookmarkedNewsDetailResponseEntity(
         bookmarkId = bookmarkId,
@@ -29,6 +31,7 @@ data class GetBookmarkedNewsDetailResponseDto (
         sentiment = sentiment,
         publishedAt = publishedAt,
         imgUrl = imgUrl,
-        category = category
+        category = category,
+        newsDeleted = newsDeleted
     )
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetHomeNewsSectionsResponseDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetHomeNewsSectionsResponseDto.kt
@@ -1,0 +1,48 @@
+package com.example.news_eat_fronted.data.model.response.home
+
+import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.entity.response.home.NewsItemEntity
+import com.example.news_eat_fronted.domain.entity.response.home.SectionEntity
+import com.google.gson.annotations.SerializedName
+
+data class GetHomeNewsSectionsResponseDto(
+    @SerializedName("isDetox")
+    val isDetox: Boolean,
+    @SerializedName("sections")
+    val sections: List<SectionDto>
+) {
+    data class SectionDto(
+        @SerializedName("type")
+        val type: String,
+        @SerializedName("title")
+        val title: String,
+        @SerializedName("newsList")
+        val newsList: List<NewsItemDto>
+    )
+
+    data class NewsItemDto(
+        @SerializedName("newsId")
+        val newsId: Long,
+        @SerializedName("imgUrl")
+        val imgUrl: String,
+        @SerializedName("title")
+        val title: String
+    )
+
+    fun toGetHomeNewsSectionResponseEntity() = GetHomeNewsSectionResponseEntity(
+        isDetox = isDetox,
+        sections = sections.map { sectionDto ->
+            SectionEntity(
+                type = sectionDto.type,
+                title = sectionDto.title,
+                newsList = sectionDto.newsList.map { newsDto ->
+                    NewsItemEntity(
+                        newsId = newsDto.newsId,
+                        imgUrl = newsDto.imgUrl,
+                        title = newsDto.title
+                    )
+                }
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetHomeNewsSectionsResponseDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetHomeNewsSectionsResponseDto.kt
@@ -20,15 +20,6 @@ data class GetHomeNewsSectionsResponseDto(
         val newsList: List<NewsItemDto>
     )
 
-    data class NewsItemDto(
-        @SerializedName("newsId")
-        val newsId: Long,
-        @SerializedName("imgUrl")
-        val imgUrl: String,
-        @SerializedName("title")
-        val title: String
-    )
-
     fun toGetHomeNewsSectionResponseEntity() = GetHomeNewsSectionResponseEntity(
         isDetox = isDetox,
         sections = sections.map { sectionDto ->
@@ -36,11 +27,7 @@ data class GetHomeNewsSectionsResponseDto(
                 type = sectionDto.type,
                 title = sectionDto.title,
                 newsList = sectionDto.newsList.map { newsDto ->
-                    NewsItemEntity(
-                        newsId = newsDto.newsId,
-                        imgUrl = newsDto.imgUrl,
-                        title = newsDto.title
-                    )
+                    newsDto.toNewsItemEntity()
                 }
             )
         }

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetLatestNewsResponseDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/GetLatestNewsResponseDto.kt
@@ -1,0 +1,13 @@
+package com.example.news_eat_fronted.data.model.response.home
+
+import com.example.news_eat_fronted.domain.entity.response.home.GetLatestNewsResponseEntity
+import com.google.gson.annotations.SerializedName
+
+data class GetLatestNewsResponseDto(
+    @SerializedName("homeNewsResponses")
+    val homeNewsResponses: List<NewsItemDto>
+) {
+    fun toGetLatestNewsResponseEntity() = GetLatestNewsResponseEntity(
+        homeNewsResponses = homeNewsResponses.map { it.toNewsItemEntity() }
+    )
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/NewsItemDto.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/model/response/home/NewsItemDto.kt
@@ -1,0 +1,19 @@
+package com.example.news_eat_fronted.data.model.response.home
+
+import com.example.news_eat_fronted.domain.entity.response.home.NewsItemEntity
+import com.google.gson.annotations.SerializedName
+
+data class NewsItemDto(
+    @SerializedName("newsId")
+    val newsId: Long,
+    @SerializedName("imgUrl")
+    val imgUrl: String,
+    @SerializedName("title")
+    val title: String
+) {
+    fun toNewsItemEntity() = NewsItemEntity(
+        newsId = newsId,
+        imgUrl = imgUrl,
+        title = title
+    )
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/BookmarkRepositoryImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/BookmarkRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.news_eat_fronted.data.repositoryImpl
 
 import com.example.news_eat_fronted.data.datasource.BookmarkRemoteDataSource
 import com.example.news_eat_fronted.domain.entity.request.bookmark.GetBookmarkListRequestEntity
+import com.example.news_eat_fronted.domain.entity.request.news.NewsSummaryResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.BookmarkIdResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.GetBookmarkListResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.GetBookmarkedNewsDetailResponseEntity
@@ -36,6 +37,13 @@ class BookmarkRepositoryImpl @Inject constructor(
         return runCatching {
             bookmarkRemoteDataSource.getBookmarkedNewsDetail(bookmarkId)
                 .result.toGetBookmarkedNewsDetailResponseEntity()
+        }.getOrElse { err -> throw err }
+    }
+
+    override suspend fun getBookmarkedNewsSummary(bookmarkId: Long): NewsSummaryResponseEntity {
+        return runCatching {
+            bookmarkRemoteDataSource.getBookmarkedNewsSummary(bookmarkId)
+                .result.toNewsSummaryResponseEntity()
         }.getOrElse { err -> throw err }
     }
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/HomeRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.news_eat_fronted.data.repositoryImpl
 
 import com.example.news_eat_fronted.data.datasource.HomeRemoteDataSource
 import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.entity.response.home.GetLatestNewsResponseEntity
 import com.example.news_eat_fronted.domain.repository.HomeRepository
 import javax.inject.Inject
 
@@ -12,6 +13,13 @@ class HomeRepositoryImpl @Inject constructor(
         return runCatching {
             homeRemoteDataSource.getHomeNewsSections()
                 .result.toGetHomeNewsSectionResponseEntity()
+        }.getOrElse { err -> throw  err }
+    }
+
+    override suspend fun getLatestNews(): GetLatestNewsResponseEntity {
+        return runCatching {
+            homeRemoteDataSource.getLatestNews()
+                .result.toGetLatestNewsResponseEntity()
         }.getOrElse { err -> throw  err }
     }
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/repositoryImpl/HomeRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.example.news_eat_fronted.data.repositoryImpl
+
+import com.example.news_eat_fronted.data.datasource.HomeRemoteDataSource
+import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.repository.HomeRepository
+import javax.inject.Inject
+
+class HomeRepositoryImpl @Inject constructor(
+    private val homeRemoteDataSource: HomeRemoteDataSource
+): HomeRepository {
+    override suspend fun getHomeNewsSections(): GetHomeNewsSectionResponseEntity {
+        return runCatching {
+            homeRemoteDataSource.getHomeNewsSections()
+                .result.toGetHomeNewsSectionResponseEntity()
+        }.getOrElse { err -> throw  err }
+    }
+}

--- a/app/src/main/java/com/example/news_eat_fronted/data/service/BookmarkService.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/service/BookmarkService.kt
@@ -4,6 +4,7 @@ import com.example.news_eat_fronted.data.model.BaseResponse
 import com.example.news_eat_fronted.data.model.response.bookmark.BookmarkIdResponseDto
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkListResponseDto
 import com.example.news_eat_fronted.data.model.response.bookmark.GetBookmarkedNewsDetailResponseDto
+import com.example.news_eat_fronted.data.model.response.news.NewsSummaryResponseDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -31,4 +32,9 @@ interface BookmarkService {
     suspend fun getBookmarkedNewsDetail(
         @Path("bookmarkId") bookmarkId: Long
     ): BaseResponse<GetBookmarkedNewsDetailResponseDto>
+
+    @POST("bookmarks/summary/{bookmarkId}")
+    suspend fun getBookmarkedNewsSummary(
+        @Path("bookmarkId") bookmarkId: Long
+    ): BaseResponse<NewsSummaryResponseDto>
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/service/HomeService.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/service/HomeService.kt
@@ -2,9 +2,13 @@ package com.example.news_eat_fronted.data.service
 
 import com.example.news_eat_fronted.data.model.BaseResponse
 import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+import com.example.news_eat_fronted.data.model.response.home.GetLatestNewsResponseDto
 import retrofit2.http.GET
 
 interface HomeService {
     @GET("home/news-sections")
     suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
+
+    @GET("home/latest-news")
+    suspend fun getLatestNews(): BaseResponse<GetLatestNewsResponseDto>
 }

--- a/app/src/main/java/com/example/news_eat_fronted/data/service/HomeService.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/data/service/HomeService.kt
@@ -1,0 +1,10 @@
+package com.example.news_eat_fronted.data.service
+
+import com.example.news_eat_fronted.data.model.BaseResponse
+import com.example.news_eat_fronted.data.model.response.home.GetHomeNewsSectionsResponseDto
+import retrofit2.http.GET
+
+interface HomeService {
+    @GET("home/news-sections")
+    suspend fun getHomeNewsSections(): BaseResponse<GetHomeNewsSectionsResponseDto>
+}

--- a/app/src/main/java/com/example/news_eat_fronted/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/di/DataSourceModule.kt
@@ -2,10 +2,12 @@ package com.example.news_eat_fronted.di
 
 import com.example.news_eat_fronted.data.datasource.AuthRemoteDataSource
 import com.example.news_eat_fronted.data.datasource.BookmarkRemoteDataSource
+import com.example.news_eat_fronted.data.datasource.HomeRemoteDataSource
 import com.example.news_eat_fronted.data.datasource.NewsRemoteDataSource
 import com.example.news_eat_fronted.data.datasource.UserRemoteDataSource
 import com.example.news_eat_fronted.data.datasourceImpl.AuthRemoteDataSourceImpl
 import com.example.news_eat_fronted.data.datasourceImpl.BookmarkRemoteDataSourceImpl
+import com.example.news_eat_fronted.data.datasourceImpl.HomeRemoteDataSourceImpl
 import com.example.news_eat_fronted.data.datasourceImpl.NewsRemoteDataSourceImpl
 import com.example.news_eat_fronted.data.datasourceImpl.UserRemoteDataSourceImpl
 import dagger.Binds
@@ -35,4 +37,9 @@ abstract class DataSourceModule {
     abstract fun bindBookmarkRemoteDataSource (
         impl: BookmarkRemoteDataSourceImpl
     ): BookmarkRemoteDataSource
+
+    @Binds
+    abstract fun bindHomeRemoteDataSource (
+        impl: HomeRemoteDataSourceImpl
+    ): HomeRemoteDataSource
 }

--- a/app/src/main/java/com/example/news_eat_fronted/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/di/RepositoryModule.kt
@@ -2,10 +2,12 @@ package com.example.news_eat_fronted.di
 
 import com.example.news_eat_fronted.data.repositoryImpl.AuthRepositoryImpl
 import com.example.news_eat_fronted.data.repositoryImpl.BookmarkRepositoryImpl
+import com.example.news_eat_fronted.data.repositoryImpl.HomeRepositoryImpl
 import com.example.news_eat_fronted.data.repositoryImpl.NewsRepositoryImpl
 import com.example.news_eat_fronted.data.repositoryImpl.UserRepositoryImpl
 import com.example.news_eat_fronted.domain.repository.AuthRepository
 import com.example.news_eat_fronted.domain.repository.BookmarkRepository
+import com.example.news_eat_fronted.domain.repository.HomeRepository
 import com.example.news_eat_fronted.domain.repository.NewsRepository
 import com.example.news_eat_fronted.domain.repository.UserRepository
 import dagger.Binds
@@ -35,4 +37,9 @@ abstract class RepositoryModule {
     abstract fun bindBookmarkRepository(
         impl: BookmarkRepositoryImpl
     ): BookmarkRepository
+
+    @Binds
+    abstract fun bindHomeRepository(
+        impl: HomeRepositoryImpl
+    ): HomeRepository
 }

--- a/app/src/main/java/com/example/news_eat_fronted/di/ServiceModule.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/di/ServiceModule.kt
@@ -2,6 +2,7 @@ package com.example.news_eat_fronted.di
 
 import com.example.news_eat_fronted.data.service.AuthService
 import com.example.news_eat_fronted.data.service.BookmarkService
+import com.example.news_eat_fronted.data.service.HomeService
 import com.example.news_eat_fronted.data.service.NewsService
 import com.example.news_eat_fronted.data.service.UserService
 import dagger.Module
@@ -34,4 +35,9 @@ object ServiceModule {
     @Singleton
     fun provideBookmarkService(@Auth retrofit: Retrofit): BookmarkService =
         retrofit.create(BookmarkService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideHomeService(@Auth retrofit: Retrofit): HomeService =
+        retrofit.create(HomeService::class.java)
 }

--- a/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/bookmark/GetBookmarkListResponseEntity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/bookmark/GetBookmarkListResponseEntity.kt
@@ -10,5 +10,6 @@ data class BookmarkResponseEntity(
     val title: String,
     val category: String,
     val imgUrl: String,
-    val publishedAt: String
+    val publishedAt: String,
+    val newsDeleted: Boolean
 )

--- a/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/bookmark/GetBookmarkedNewsDetailResponseEntity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/bookmark/GetBookmarkedNewsDetailResponseEntity.kt
@@ -8,5 +8,6 @@ data class GetBookmarkedNewsDetailResponseEntity (
     val sentiment: String,
     val publishedAt: String,
     val imgUrl: String,
-    val category: String
+    val category: String,
+    val newsDeleted: Boolean
 )

--- a/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/home/GetHomeNewsSectionResponseEntity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/home/GetHomeNewsSectionResponseEntity.kt
@@ -1,0 +1,18 @@
+package com.example.news_eat_fronted.domain.entity.response.home
+
+data class GetHomeNewsSectionResponseEntity (
+    val isDetox: Boolean,
+    val sections: List<SectionEntity>
+)
+
+data class SectionEntity(
+    val type: String,
+    val title: String,
+    val newsList: List<NewsItemEntity>
+)
+
+data class NewsItemEntity(
+    val newsId: Long,
+    val imgUrl: String,
+    val title: String
+)

--- a/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/home/GetLatestNewsResponseEntity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/entity/response/home/GetLatestNewsResponseEntity.kt
@@ -1,0 +1,5 @@
+package com.example.news_eat_fronted.domain.entity.response.home
+
+data class GetLatestNewsResponseEntity(
+    val homeNewsResponses: List<NewsItemEntity>
+)

--- a/app/src/main/java/com/example/news_eat_fronted/domain/repository/BookmarkRepository.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/repository/BookmarkRepository.kt
@@ -1,6 +1,7 @@
 package com.example.news_eat_fronted.domain.repository
 
 import com.example.news_eat_fronted.domain.entity.request.bookmark.GetBookmarkListRequestEntity
+import com.example.news_eat_fronted.domain.entity.request.news.NewsSummaryResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.BookmarkIdResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.GetBookmarkListResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.bookmark.GetBookmarkedNewsDetailResponseEntity
@@ -13,4 +14,6 @@ interface BookmarkRepository {
     suspend fun getBookmarkList(getBookmarkListRequestEntity: GetBookmarkListRequestEntity): GetBookmarkListResponseEntity
 
     suspend fun getBookmarkedNewsDetail(bookmarkId: Long): GetBookmarkedNewsDetailResponseEntity
+
+    suspend fun getBookmarkedNewsSummary(bookmarkId: Long): NewsSummaryResponseEntity
 }

--- a/app/src/main/java/com/example/news_eat_fronted/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/repository/HomeRepository.kt
@@ -1,7 +1,10 @@
 package com.example.news_eat_fronted.domain.repository
 
 import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.entity.response.home.GetLatestNewsResponseEntity
 
 interface HomeRepository {
     suspend fun getHomeNewsSections(): GetHomeNewsSectionResponseEntity
+
+    suspend fun getLatestNews(): GetLatestNewsResponseEntity
 }

--- a/app/src/main/java/com/example/news_eat_fronted/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/repository/HomeRepository.kt
@@ -1,0 +1,7 @@
+package com.example.news_eat_fronted.domain.repository
+
+import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+
+interface HomeRepository {
+    suspend fun getHomeNewsSections(): GetHomeNewsSectionResponseEntity
+}

--- a/app/src/main/java/com/example/news_eat_fronted/domain/usecase/bookmark/GetBookmarkedNewsSummaryUseCase.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/usecase/bookmark/GetBookmarkedNewsSummaryUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.news_eat_fronted.domain.usecase.bookmark
+
+import com.example.news_eat_fronted.domain.repository.BookmarkRepository
+import javax.inject.Inject
+
+class GetBookmarkedNewsSummaryUseCase @Inject constructor(
+    private val bookmarkRepository: BookmarkRepository
+) {
+    suspend operator fun invoke(bookmarkId: Long)
+    = bookmarkRepository.getBookmarkedNewsSummary(bookmarkId)
+}

--- a/app/src/main/java/com/example/news_eat_fronted/domain/usecase/home/GetHomeNewsSectionsUseCase.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/usecase/home/GetHomeNewsSectionsUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.news_eat_fronted.domain.usecase.home
+
+import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.repository.HomeRepository
+import javax.inject.Inject
+
+class GetHomeNewsSectionsUseCase @Inject constructor(
+    private val homeRepository: HomeRepository
+) {
+    suspend operator fun invoke(): GetHomeNewsSectionResponseEntity
+    = homeRepository.getHomeNewsSections()
+}

--- a/app/src/main/java/com/example/news_eat_fronted/domain/usecase/home/GetLatestNewsUseCase.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/usecase/home/GetLatestNewsUseCase.kt
@@ -1,12 +1,11 @@
 package com.example.news_eat_fronted.domain.usecase.home
 
-import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
 import com.example.news_eat_fronted.domain.repository.HomeRepository
 import javax.inject.Inject
 
-class GetHomeNewsSectionsUseCase @Inject constructor(
+class GetLatestNewsUseCase @Inject constructor(
     private val homeRepository: HomeRepository
 ) {
     suspend operator fun invoke()
-    = homeRepository.getHomeNewsSections()
+    = homeRepository.getLatestNews()
 }

--- a/app/src/main/java/com/example/news_eat_fronted/domain/usecase/user/SetDetoxModeUseCase.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/domain/usecase/user/SetDetoxModeUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class SetDetoxModeUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(setDetoxModeRequestEntity: SetDetoxModeRequestEntity): SetDetoxModeResponseEntity
+    suspend operator fun invoke(setDetoxModeRequestEntity: SetDetoxModeRequestEntity)
     = userRepository.setDetoxMode(setDetoxModeRequestEntity)
 }

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/bookmark/BookmarkFragment.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/bookmark/BookmarkFragment.kt
@@ -12,6 +12,7 @@ import com.example.news_eat_fronted.databinding.FragmentBookmarkBinding
 import com.example.news_eat_fronted.presentation.ui.news.NewsDetailActivity
 import com.example.news_eat_fronted.util.CustomSnackBar
 import com.example.news_eat_fronted.util.base.BindingFragment
+import com.example.news_eat_fronted.util.dialog.DialogPopupFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -39,7 +40,20 @@ class BookmarkFragment : BindingFragment<FragmentBookmarkBinding>(R.layout.fragm
         adapter = RVAdapterBookmark(
             bookmarkList = arrayListOf(),
             onSelectionChanged = { item ->
-                bookmarkViewModel.deleteBookmark(item.bookmarkId) // 북마크 취소
+                // 북마크 취소
+                if(item.newsDeleted) {
+                    val dialog = DialogPopupFragment(
+                        title = getString(R.string.bookmarked_news_delete_title),
+                        content = getString(R.string.bookmarked_news_delete_content),
+                        leftBtnText = getString(R.string.dialog_btn_cancel),
+                        rightBtnText = getString(R.string.dialog_btn_delete_bookmarked_news),
+                        clickLeftBtn = {},
+                        clickRightBtn = { bookmarkViewModel.deleteBookmark(item.bookmarkId)  }
+                    )
+                    dialog.show(parentFragmentManager, "DialogDelete")
+                } else {
+                    bookmarkViewModel.deleteBookmark(item.bookmarkId)
+                }
             },
             onSelectItem = { item ->
                 startActivity(Intent(requireContext(), NewsDetailActivity::class.java).apply {

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeFragment.kt
@@ -28,6 +28,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         switchDetoxMode()
 
         homeViewModel.getHomeNewsSections()
+        homeViewModel.getLatestNews()
     }
 
     private fun setAdapter() {
@@ -131,6 +132,14 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
                         positiveNews?.let { section ->
                             positiveAdapter.submitList(section.newsList)
                         }
+                    }
+                }
+            }
+
+            launch {
+                homeViewModel.latestNewsState.collect { latestNewsState ->
+                    latestNewsState?.let {
+                        recommendAdapter.submitList(latestNewsState.homeNewsResponses)
                     }
                 }
             }

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.news_eat_fronted.R
 import com.example.news_eat_fronted.domain.entity.request.user.SetDetoxModeRequestEntity
+import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.entity.response.home.NewsItemEntity
 import com.example.news_eat_fronted.domain.entity.response.user.SetDetoxModeResponseEntity
+import com.example.news_eat_fronted.domain.usecase.home.GetHomeNewsSectionsUseCase
 import com.example.news_eat_fronted.domain.usecase.user.SetDetoxModeUseCase
 import com.example.news_eat_fronted.presentation.model.CategoryItem
 import com.example.news_eat_fronted.presentation.model.HomeNewsItem
@@ -16,12 +19,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val setDetoxModeUseCase: SetDetoxModeUseCase
+    private val setDetoxModeUseCase: SetDetoxModeUseCase,
+    private val getHomeNewsSectionsUseCase: GetHomeNewsSectionsUseCase
 ): ViewModel() {
     private val _nickname = MutableStateFlow("쫀득물만두")
     val nickname: StateFlow<String> = _nickname
 
-    private val _interests = MutableStateFlow<List<String>>(listOf("경제", "연예"))
+    private val _interests = MutableStateFlow<List<String>>(listOf())
     val interests: StateFlow<List<String>> = _interests
 
     val categoryListMap = mapOf(
@@ -35,23 +39,12 @@ class HomeViewModel @Inject constructor(
         "세계" to CategoryItem(8, R.drawable.category_world_unselected, R.string.category_world),
     )
 
-    private val _recommendList = MutableStateFlow<List<HomeNewsItem>>(emptyList())
-    val recommendList: StateFlow<List<HomeNewsItem>> = _recommendList
+    private val _recommendList = MutableStateFlow<List<NewsItemEntity>>(emptyList())
+    val recommendList: StateFlow<List<NewsItemEntity>> = _recommendList
 
-    private val _category1List = MutableStateFlow<List<HomeNewsItem>>(emptyList())
-    val category1List: StateFlow<List<HomeNewsItem>> = _category1List
 
-    private val _category2List = MutableStateFlow<List<HomeNewsItem>>(emptyList())
-    val category2List: StateFlow<List<HomeNewsItem>> = _category2List
-
-    private val _category3List = MutableStateFlow<List<HomeNewsItem>>(emptyList())
-    val category3List: StateFlow<List<HomeNewsItem>> = _category3List
-
-    private val _positiveList = MutableStateFlow<List<HomeNewsItem>>(emptyList())
-    val positiveList: StateFlow<List<HomeNewsItem>> = _positiveList
-
-    private val _setDetoxModeState = MutableStateFlow<SetDetoxModeResponseEntity?>(null)
-    val setDetoxModeState: StateFlow<SetDetoxModeResponseEntity?> = _setDetoxModeState
+    private val _homeNewsSectionsState = MutableStateFlow<GetHomeNewsSectionResponseEntity?>(null)
+    val homeNewsSectionsState: StateFlow<GetHomeNewsSectionResponseEntity?> = _homeNewsSectionsState
 
     fun setDetoxMode(isChecked: Boolean) {
         viewModelScope.launch {
@@ -61,51 +54,20 @@ class HomeViewModel @Inject constructor(
                         isDetoxMode = isChecked
                     )
                 )
-                _setDetoxModeState.value = setDetoxModeResponseEntity
             } catch (ex: Exception) {}
         }
     }
 
-    init {
-        // 더미데이터 초기화
-        _recommendList.value = listOf(
-            HomeNewsItem(id = 1, "https://cphoto.asiae.co.kr/listimglink/1/2025051719272061633_1747477641.jpg", "‘던파’ 흥행에 넥슨 네오플 평균 연봉 2.2억원…업계 1위-뉴스제목입니다 최대 두줄노출"),
-            HomeNewsItem(id = 2, "https://imgnews.pstatic.net/image/003/2025/08/07/NISI20250807_0001912788_web_20250807103749_20250807104215055.jpg?type=w647", "실리콘밸리에 VC 만드는 네이버…\"AI 총력전\""),
-            HomeNewsItem(id = 3, "https://file2.nocutnews.co.kr/newsroom/image/2024/04/01/202404011752096007_0.jpg", "이제 겨우 스물네살인데, 영구결번 전설적 투수를 넘어섰다…역사를 쓰는 정해영"),
-            HomeNewsItem(id = 4, "https://file2.nocutnews.co.kr/newsroom/image/2025/05/17/202505171702116972_0.jpg", "\"김혜성, 마법 지팡이라도 들고 있는 것 같아\" ML 명장도 인정한 존재감, 빅리그 잔류 가능성 높아지나"),
-            HomeNewsItem(id = 5, "https://img.khan.co.kr/news/2022/08/01/l_2022080201000076500004271.webp", "'불닭' 파워에 주가 폭등한 삼양식품, 사옥도 '이곳'으로 옮긴다")
-        )
+    fun getHomeNewsSections() {
+        viewModelScope.launch {
+            try {
+                val getHomeNewsSectionsResponseEntity = getHomeNewsSectionsUseCase()
+                _homeNewsSectionsState.value = getHomeNewsSectionsResponseEntity
+            } catch (ex: Exception) {}
+        }
+    }
 
-        _category1List.value = listOf(
-            HomeNewsItem(id = 1, "https://cphoto.asiae.co.kr/listimglink/1/2025051719272061633_1747477641.jpg", "111‘던파’ 흥행에 넥슨 네오플 평균 연봉 2.2억원…업계 1위-뉴스제목입니다 최대 두줄노출"),
-            HomeNewsItem(id = 2, "https://imgnews.pstatic.net/image/003/2025/08/07/NISI20250807_0001912788_web_20250807103749_20250807104215055.jpg?type=w647", "222실리콘밸리에 VC 만드는 네이버…\"AI 총력전\""),
-            HomeNewsItem(id = 3, "https://file2.nocutnews.co.kr/newsroom/image/2024/04/01/202404011752096007_0.jpg", "333이제 겨우 스물네살인데, 영구결번 전설적 투수를 넘어섰다…역사를 쓰는 정해영"),
-            HomeNewsItem(id = 4, "https://file2.nocutnews.co.kr/newsroom/image/2025/05/17/202505171702116972_0.jpg", "444김혜성, 마법 지팡이라도 들고 있는 것 같아 ML 명장도 인정한 존재감, 빅리그 잔류 가능성 높아지나"),
-            HomeNewsItem(id = 5, "https://img.khan.co.kr/news/2022/08/01/l_2022080201000076500004271.webp", "'555불닭' 파워에 주가 폭등한 삼양식품, 사옥도 '이곳'으로 옮긴다")
-        )
-
-        _category2List.value = listOf(
-            HomeNewsItem(id = 1, "https://cdn.dailycnc.com/news/photo/202303/217256_225001_441.png", "[겜쇼분석] 던파모바일과 함께한 1주년! 모바일 액션 RPG의 ‘새로운 도약’은?"),
-            HomeNewsItem(id = 2, "https://img.khan.co.kr/news/r/700xX/2025/08/08/news-p.v1.20250808.c6b77c2b896f4e48b7feffba32eed5ee_P1.webp", "김문수 “윤석열 인권 짓밟더니 범죄자 조국에겐 꽃길 깔아줘” 사면 논의 비판"),
-            HomeNewsItem(id = 3, "https://img.khan.co.kr/news/r/700xX/2025/08/08/news-p.v1.20250808.6d3e2885b78645dd83e1605368982f08_P1.webp", "충주서 대몽항쟁 역사 담긴 고려시대 토성 출토…충주시, 학술조사 실시"),
-            HomeNewsItem(id = 4, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250808.c486d95163984355b0974fc4a20a46b5_P1.webp", "열대야 잊게 할 우주쇼…증평 좌구산 천문대 ‘페르세우스 유성우 관측 행사’"),
-            HomeNewsItem(id = 5, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250808.0ce60b31320a4d7995fef0037e8f3c92_P1.webp", "'찌는 여름···베스트셀러 순위에서 만화책 약진")
-        )
-//
-//        _category3List.value = listOf(
-//            HomeNewsItem(id = 1, "https://cdn.dailycnc.com/news/photo/202303/217256_225001_441.png", "111[겜쇼분석] 던파모바일과 함께한 1주년! 모바일 액션 RPG의 ‘새로운 도약’은?"),
-//            HomeNewsItem(id = 2, "https://img.khan.co.kr/news/r/700xX/2025/08/08/news-p.v1.20250808.c6b77c2b896f4e48b7feffba32eed5ee_P1.webp", "222김문수 “윤석열 인권 짓밟더니 범죄자 조국에겐 꽃길 깔아줘” 사면 논의 비판"),
-//            HomeNewsItem(id = 3, "https://img.khan.co.kr/news/r/700xX/2025/08/08/news-p.v1.20250808.6d3e2885b78645dd83e1605368982f08_P1.webp", "333충주서 대몽항쟁 역사 담긴 고려시대 토성 출토…충주시, 학술조사 실시"),
-//            HomeNewsItem(id = 4, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250808.c486d95163984355b0974fc4a20a46b5_P1.webp", "444열대야 잊게 할 우주쇼…증평 좌구산 천문대 ‘페르세우스 유성우 관측 행사’"),
-//            HomeNewsItem(id = 5, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250808.0ce60b31320a4d7995fef0037e8f3c92_P1.webp", "555'찌는 여름···베스트셀러 순위에서 만화책 약진")
-//        )
-
-        _positiveList.value = listOf(
-            HomeNewsItem(id = 1, "https://img.khan.co.kr/news/2025/08/07/l_2025080801000200500019641.webp", "화장실 왜 또 가냐고? 여성의 방광이 답한다"),
-            HomeNewsItem(id = 2, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250807.dc17e1d9b1de4f2885fbc7b17fa0eebf_P1.webp", "강릉 의원서 허리 시술 뒤 ‘집단 이상 증상’…22명으로 늘어"),
-            HomeNewsItem(id = 3, "https://img.khan.co.kr/news/r/700xX/2025/08/06/news-p.v1.20250806.eff8a77b17c84238bb236974f9c8708d_P1.webp", "에어부산, 7~13일 일본 항공권 최저 3만원대 특가"),
-            HomeNewsItem(id = 4, "https://img.khan.co.kr/news/2025/08/08/news-p.v1.20250808.e9de78d092df46ceaf27f8600d5a2134_P1.webp", "은마 맞은편 ‘대치쌍용1차’ 최고 49층 999가구 단지로 탈바꿈"),
-            HomeNewsItem(id = 5, "https://img.khan.co.kr/news/r/700xX/2025/08/08/news-p.v1.20250808.3b2d97dd2fe54a538d5895532868a09c_P1.webp", "“박사급 전문가 수준”···오픈 AI, 최신 AI 모델 ‘GPT-5’ 공개")
-        )
+    fun setInterest(interest: List<String>) {
+        _interests.value = interest
     }
 }

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/HomeViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.viewModelScope
 import com.example.news_eat_fronted.R
 import com.example.news_eat_fronted.domain.entity.request.user.SetDetoxModeRequestEntity
 import com.example.news_eat_fronted.domain.entity.response.home.GetHomeNewsSectionResponseEntity
+import com.example.news_eat_fronted.domain.entity.response.home.GetLatestNewsResponseEntity
 import com.example.news_eat_fronted.domain.entity.response.home.NewsItemEntity
 import com.example.news_eat_fronted.domain.entity.response.user.SetDetoxModeResponseEntity
 import com.example.news_eat_fronted.domain.usecase.home.GetHomeNewsSectionsUseCase
+import com.example.news_eat_fronted.domain.usecase.home.GetLatestNewsUseCase
 import com.example.news_eat_fronted.domain.usecase.user.SetDetoxModeUseCase
 import com.example.news_eat_fronted.presentation.model.CategoryItem
 import com.example.news_eat_fronted.presentation.model.HomeNewsItem
@@ -20,7 +22,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val setDetoxModeUseCase: SetDetoxModeUseCase,
-    private val getHomeNewsSectionsUseCase: GetHomeNewsSectionsUseCase
+    private val getHomeNewsSectionsUseCase: GetHomeNewsSectionsUseCase,
+    private val getLatestNewsUseCase: GetLatestNewsUseCase
 ): ViewModel() {
     private val _nickname = MutableStateFlow("쫀득물만두")
     val nickname: StateFlow<String> = _nickname
@@ -46,6 +49,9 @@ class HomeViewModel @Inject constructor(
     private val _homeNewsSectionsState = MutableStateFlow<GetHomeNewsSectionResponseEntity?>(null)
     val homeNewsSectionsState: StateFlow<GetHomeNewsSectionResponseEntity?> = _homeNewsSectionsState
 
+    private val _latestNewsState = MutableStateFlow<GetLatestNewsResponseEntity?>(null)
+    val latestNewsState: StateFlow<GetLatestNewsResponseEntity?> = _latestNewsState
+
     fun setDetoxMode(isChecked: Boolean) {
         viewModelScope.launch {
             try {
@@ -63,6 +69,15 @@ class HomeViewModel @Inject constructor(
             try {
                 val getHomeNewsSectionsResponseEntity = getHomeNewsSectionsUseCase()
                 _homeNewsSectionsState.value = getHomeNewsSectionsResponseEntity
+            } catch (ex: Exception) {}
+        }
+    }
+
+    fun getLatestNews() {
+        viewModelScope.launch {
+            try {
+                val getLatestNewsResponseEntity = getLatestNewsUseCase()
+                _latestNewsState.value = getLatestNewsResponseEntity
             } catch (ex: Exception) {}
         }
     }

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/RVAdapterNews.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/home/RVAdapterNews.kt
@@ -7,9 +7,10 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.news_eat_fronted.databinding.RvHomeNewsItemBinding
+import com.example.news_eat_fronted.domain.entity.response.home.NewsItemEntity
 import com.example.news_eat_fronted.presentation.model.HomeNewsItem
 
-class RVAdapterNews: ListAdapter<HomeNewsItem, RVAdapterNews.ViewHolder>(DIFF_CALLBACK) {
+class RVAdapterNews: ListAdapter<NewsItemEntity, RVAdapterNews.ViewHolder>(DIFF_CALLBACK) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RVAdapterNews.ViewHolder {
         val binding = RvHomeNewsItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ViewHolder(binding)
@@ -20,22 +21,22 @@ class RVAdapterNews: ListAdapter<HomeNewsItem, RVAdapterNews.ViewHolder>(DIFF_CA
     }
 
     inner class ViewHolder(private val binding: RvHomeNewsItemBinding): RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: HomeNewsItem) {
+        fun bind(item: NewsItemEntity) {
             Glide.with(binding.root)
 //                .load(binding.root.context.resources.getIdentifier(item.imgResId, "drawable", binding.root.context.packageName))
-                .load(item.imgResId)
+                .load(item.imgUrl)
                 .into(binding.ivHomeNews)
             binding.tvHomeNews.text = item.title
         }
     }
 
     companion object {
-        private val DIFF_CALLBACK = object: DiffUtil.ItemCallback<HomeNewsItem>() {
-            override fun areItemsTheSame(oldItem: HomeNewsItem, newItem: HomeNewsItem): Boolean {
-                return oldItem.id == newItem.id
+        private val DIFF_CALLBACK = object: DiffUtil.ItemCallback<NewsItemEntity>() {
+            override fun areItemsTheSame(oldItem: NewsItemEntity, newItem: NewsItemEntity): Boolean {
+                return oldItem.newsId == newItem.newsId
             }
 
-            override fun areContentsTheSame(oldItem: HomeNewsItem, newItem: HomeNewsItem): Boolean {
+            override fun areContentsTheSame(oldItem: NewsItemEntity, newItem: NewsItemEntity): Boolean {
                 return oldItem == newItem
             }
 

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
@@ -44,6 +44,7 @@ class NewsDetailActivity : BindingActivity<ActivityNewsDetailBinding>(R.layout.a
             viewModel.setGetBookmarkedNews(true)
             viewModel.setBookmarkId(intent.getLongExtra("bookmarkId", -1L))
             viewModel.getBookmarkedNewsDetail()
+            viewModel.getBookmarkedNewsSummary()
 
             binding.apply {
                 newsDetailDiver.visibility = View.GONE
@@ -168,6 +169,7 @@ class NewsDetailActivity : BindingActivity<ActivityNewsDetailBinding>(R.layout.a
 
     private fun addListeners() {
         binding.summaryButton.setOnClickListener {
+            // 뉴스 요약
             viewModel.newsSummaryState.value?.let { newsSummaryState ->
                 val dialog = DialogSummaryFragment(
                     title = newsSummaryState.title,

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsDetailActivity.kt
@@ -209,15 +209,19 @@ class NewsDetailActivity : BindingActivity<ActivityNewsDetailBinding>(R.layout.a
                 }
             } else {
                 // 북마크된 뉴스 삭제
-                val dialog = DialogPopupFragment(
-                    title = getString(R.string.bookmarked_news_delete_title),
-                    content = getString(R.string.bookmarked_news_delete_content),
-                    leftBtnText = getString(R.string.dialog_btn_cancel),
-                    rightBtnText = getString(R.string.dialog_btn_delete_bookmarked_news),
-                    clickLeftBtn = {},
-                    clickRightBtn = { viewModel.deleteBookmark() }
-                )
-                dialog.show(supportFragmentManager, "DialogDelete")
+                if(viewModel.bookmarkedNewsDetail.value?.newsDeleted == true) {
+                    val dialog = DialogPopupFragment(
+                        title = getString(R.string.bookmarked_news_delete_title),
+                        content = getString(R.string.bookmarked_news_delete_content),
+                        leftBtnText = getString(R.string.dialog_btn_cancel),
+                        rightBtnText = getString(R.string.dialog_btn_delete_bookmarked_news),
+                        clickLeftBtn = {},
+                        clickRightBtn = { viewModel.deleteBookmark() }
+                    )
+                    dialog.show(supportFragmentManager, "DialogDelete")
+                } else {
+                    viewModel.deleteBookmark()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsViewModel.kt
+++ b/app/src/main/java/com/example/news_eat_fronted/presentation/ui/news/NewsViewModel.kt
@@ -9,6 +9,7 @@ import com.example.news_eat_fronted.domain.entity.response.bookmark.GetBookmarke
 import com.example.news_eat_fronted.domain.entity.response.news.GetRecommendationsResponseEntity
 import com.example.news_eat_fronted.domain.usecase.bookmark.DeleteBookmarkUseCase
 import com.example.news_eat_fronted.domain.usecase.bookmark.GetBookmarkedNewsDetailUseCase
+import com.example.news_eat_fronted.domain.usecase.bookmark.GetBookmarkedNewsSummaryUseCase
 import com.example.news_eat_fronted.domain.usecase.bookmark.PostBookmarkUseCase
 import com.example.news_eat_fronted.domain.usecase.news.GetNewsDetailUseCase
 import com.example.news_eat_fronted.domain.usecase.news.GetNewsSummaryUseCase
@@ -28,7 +29,8 @@ class NewsViewModel @Inject constructor(
     private val postBookmarkUseCase: PostBookmarkUseCase,
     private val deleteBookmarkUseCase: DeleteBookmarkUseCase,
     private val getBookmarkedNewsDetailUseCase: GetBookmarkedNewsDetailUseCase,
-    private val getRecommendationsUseCase: GetRecommendationsUseCase
+    private val getRecommendationsUseCase: GetRecommendationsUseCase,
+    private val getBookmarkedNewsSummaryUseCase: GetBookmarkedNewsSummaryUseCase
 ) : ViewModel() {
 
     private val _newsId = MutableStateFlow<Long>(-1L)
@@ -121,6 +123,17 @@ class NewsViewModel @Inject constructor(
                     bookmarkId = _bookmarkId.value
                 )
                 _bookmarkedNewsDetail.value = getBookmarkedNewsDetail
+            } catch (ex: Exception) {}
+        }
+    }
+
+    fun getBookmarkedNewsSummary() {
+        viewModelScope.launch {
+            try {
+                val bookmarkedNewsSummaryResponse = getBookmarkedNewsSummaryUseCase(
+                    bookmarkId = _bookmarkId.value
+                )
+                _newsSummaryState.value = bookmarkedNewsSummaryResponse
             } catch (ex: Exception) {}
         }
     }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #23


## ✏️ 작업 내용

- 북마크한 뉴스 내용 요약 API 연결
- 북마크 취소 로직 수정 API 연결
- 홈화면 통합 뉴스 조회 API 연결
- 홈화면 최신 뉴스 조회 API 연결


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
디톡스모드 토글할때마다 홈화면 뉴스 다시 가져오는 로직 구현안함
